### PR TITLE
[IMPROVE] Make the Action faster

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,8 +2,6 @@ name: Test the Action
 
 on:
   - push
-  - pull_request
-
 
 jobs:
   example_job:
@@ -11,8 +9,6 @@ jobs:
     name: test the action
     steps:
       - uses: actions/checkout@v2
-        with:
-          persist-credentials: false
       - name: test
         uses: ./
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ jobs:
     steps:
       - uses: actions/checkout@master
       - name: test
-        uses: aditya-mitra/algolia-docsearch-action@master
+        uses: aditya-mitra/algolia-docsearch-action@improve/actions
         with:
           algolia_api_key: ${{ secrets.ALGOLIA_API_KEY }}
           algolia_application_id: ${{ secrets.ALGOLIA_APPLICATION_ID }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,14 +1,19 @@
+name: Test the Action
+
 on:
   - push
+
 
 jobs:
   example_job:
     runs-on: ubuntu-latest
     name: test the action
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v2
+        with:
+          persist-credentials: false
       - name: test
-        uses: aditya-mitra/algolia-docsearch-action@improve/actions
+        uses: darrenjennings/algolia-docsearch-action@master
         with:
           algolia_api_key: ${{ secrets.ALGOLIA_API_KEY }}
           algolia_application_id: ${{ secrets.ALGOLIA_APPLICATION_ID }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,6 +2,7 @@ name: Test the Action
 
 on:
   - push
+  - pull_request
 
 
 jobs:
@@ -13,7 +14,7 @@ jobs:
         with:
           persist-credentials: false
       - name: test
-        uses: darrenjennings/algolia-docsearch-action@master
+        uses: ./
         with:
           algolia_api_key: ${{ secrets.ALGOLIA_API_KEY }}
           algolia_application_id: ${{ secrets.ALGOLIA_APPLICATION_ID }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,5 @@
-on: [push]
+on:
+  - push
 
 jobs:
   example_job:
@@ -7,7 +8,7 @@ jobs:
     steps:
       - uses: actions/checkout@master
       - name: test
-        uses: darrenjennings/algolia-docsearch-action@master
+        uses: aditya-mitra/algolia-docsearch-action@master
         with:
           algolia_api_key: ${{ secrets.ALGOLIA_API_KEY }}
           algolia_application_id: ${{ secrets.ALGOLIA_APPLICATION_ID }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:latest
+FROM alpine:latest
 
 COPY entrypoint.sh /entrypoint.sh
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:alpine
+FROM ubuntu:latest
 
 COPY entrypoint.sh /entrypoint.sh
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,5 @@
 FROM python:3.6
 
-RUN apt update && apt install jq git -y
-
-WORKDIR /action
-
-RUN git clone https://github.com/algolia/docsearch-scraper.git
-
-WORKDIR /action/docsearch-scraper
-
-RUN pip install pipenv
-
-RUN pipenv install --system --ignore-pipfile
-
-WORKDIR /action
-
-COPY entrypoint.sh /action/entrypoint.sh
+COPY entrypoint.sh /entrypoint.sh
 
 ENTRYPOINT ["/action/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@ FROM ubuntu:latest
 
 RUN apt update && apt install jq -y
 
+RUN apt install apt-transport-https ca-certificates curl software-properties-common -y
 RUN curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add -
 RUN add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu bionic stable"
 RUN apt update

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,4 +2,4 @@ FROM python:3.6
 
 COPY entrypoint.sh /entrypoint.sh
 
-ENTRYPOINT ["/action/entrypoint.sh"]
+ENTRYPOINT ["/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,19 @@
 FROM python:3.6
 
+RUN apt update && apt install jq git -y
+
+WORKDIR /action
+
 RUN git clone https://github.com/algolia/docsearch-scraper.git
 
-WORKDIR /docsearch-scraper
+WORKDIR /action/docsearch-scraper
 
 RUN pip install pipenv
 
 RUN pipenv install --system --ignore-pipfile
 
-COPY entrypoint.sh /entrypoint.sh
+WORKDIR /action
 
-ENTRYPOINT ["/entrypoint.sh"]
+COPY entrypoint.sh /action/entrypoint.sh
+
+ENTRYPOINT ["/action/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,10 @@
-FROM ubuntu:latest
+FROM algolia/docsearch-scraper
 
 RUN apt update && apt install jq -y
 
-RUN apt install apt-transport-https ca-certificates curl software-properties-common -y
-RUN curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add -
-RUN add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu bionic stable"
-RUN apt update
-RUN apt-cache policy docker-ce
-RUN apt install docker-ce -y
+WORKDIR /algolia-docsearch-action
+
+COPY config.example.json /config.example.json
 
 COPY entrypoint.sh /entrypoint.sh
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,12 @@
-FROM algolia/docsearch-scraper
+FROM python:3.6
 
-RUN apt update && apt install jq -y
+RUN git clone https://github.com/algolia/docsearch-scraper.git
 
-WORKDIR /algolia-docsearch-action
+WORKDIR /docsearch-scraper
 
-COPY config.example.json /config.example.json
+RUN pip install pipenv
+
+RUN pipenv install --system --ignore-pipfile
 
 COPY entrypoint.sh /entrypoint.sh
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,12 @@
-FROM alpine:latest
+FROM ubuntu:latest
+
+RUN apt update && apt install jq -y
+
+RUN curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add -
+RUN add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu bionic stable"
+RUN apt update
+RUN apt-cache policy docker-ce
+RUN apt install docker-ce -y
 
 COPY entrypoint.sh /entrypoint.sh
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6-slim
+FROM python:3.6
 
 COPY entrypoint.sh /entrypoint.sh
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6
+FROM python:3.6-slim
 
 COPY entrypoint.sh /entrypoint.sh
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:latest
+FROM ubuntu:alpine
 
 COPY entrypoint.sh /entrypoint.sh
 

--- a/README.md
+++ b/README.md
@@ -5,14 +5,13 @@ This action runs the docsearch scraper and updates an index.
 ## Inputs
 
 ### `algolia_application_id`
-**Required** 'Aloglia docsearch `APPLICATION_ID`
+**Required** Algolia docsearch `APPLICATION_ID`
 
 ### `algolia_api_key`
-**Required** Aloglia docsearch `API_KEY`
+**Required** Algolia docsearch `API_KEY`
 
 ### `file`
-**Required** File able to be accessed from $GITHUB_WORKSPACE, used in tandem
-with `actions/checkout@master`
+**Required** File able to be accessed from $GITHUB_WORKSPACE, used in tandem with `actions/checkout@master`
 
 ## Example usage
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This action runs the docsearch scraper and updates an index.
 ## Example usage
 
 ```yaml
-- uses: actions/checkout@master
+- uses: actions/checkout@v2
 - uses: darrenjennings/algolia-docsearch-action@master
   with:
     algolia_application_id: 'XXXXX83LWT'

--- a/action.yml
+++ b/action.yml
@@ -5,10 +5,10 @@ branding:
   color: 'blue'
 inputs:
   algolia_application_id:
-    description: 'Aloglia docsearch APPLICATION_ID'
+    description: 'Algolia docsearch APPLICATION_ID'
     required: true
   algolia_api_key:
-    description: 'Aloglia docsearch API_KEY'
+    description: 'Algolia docsearch API_KEY'
     required: true
   file:
     description: 'File path to docsearch'

--- a/config.example.json
+++ b/config.example.json
@@ -1,41 +1,20 @@
 {
-  "index_name": "prod_EE",
+  "index_name": "CovidSusTrackerDocs",
   "start_urls": [
-    {
-      "url": "https://docs.konghq.com/enterprise/(?P<version>.*?)/",
-      "variables": {
-        "version": {
-          "url": "https://docs.konghq.com/enterprise/",
-          "js": "var versions = $('ul[aria-labelledby=version-dropdown] a, button#version-dropdown').map(function(i, e) { return $(e).text().replace(/\\s+/g, '').replace(/Version/g, '').replace('(2020)', '').replace('(latest)', ''); }).toArray(); return JSON.stringify(versions);"
-        }
-      }
-    }
+    "https://aquaimpact.github.io/CovidSusTrackerDocs"
   ],
-  "sitemap_urls": [
-    "https://docs.konghq.com/sitemap.xml"
-  ],
-  "stop_urls": [
-
-  ],
+  "stop_urls": [],
   "selectors": {
-    "lvl0": {
-      "selector": ".docs-navigation > a.active",
-      "global": true,
-      "default_value": "Kong"
-    },
-    "lvl1": ".content h1",
-    "lvl2": ".content h2",
-    "lvl3": ".content h3",
-    "lvl4": ".content h4",
-    "text": ".content p, .content li"
+    "lvl0": ".doc-content h1",
+    "lvl1": ".doc-content h2",
+    "lvl2": ".doc-content h3",
+    "lvl3": ".doc-content h4",
+    "lvl4": ".doc-content h5",
+    "lvl5": ".doc-content h6",
+    "text": ".doc-content p, .doc-content li"
   },
-  "selectors_exclude": [
-    "#next-steps",
-    "#next-steps ~ p"
-  ],
-  "only_content_level": true,
   "conversation_id": [
-    "534091583"
+    "1313246279"
   ],
-  "nb_hits": 18645
+  "nb_hits": 98
 }

--- a/config.example.json
+++ b/config.example.json
@@ -1,20 +1,37 @@
 {
-  "index_name": "CovidSusTrackerDocs",
-  "start_urls": [
-    "https://aquaimpact.github.io/CovidSusTrackerDocs"
-  ],
-  "stop_urls": [],
-  "selectors": {
-    "lvl0": ".doc-content h1",
-    "lvl1": ".doc-content h2",
-    "lvl2": ".doc-content h3",
-    "lvl3": ".doc-content h4",
-    "lvl4": ".doc-content h5",
-    "lvl5": ".doc-content h6",
-    "text": ".doc-content p, .doc-content li"
-  },
-  "conversation_id": [
-    "1313246279"
-  ],
-  "nb_hits": 98
+	"index_name": "cpnotes_index",
+	"start_urls": ["https://cpnotes-preview.netlify.app/"],
+	"sitemap_urls": ["https://cpnotes-preview.netlify.app/sitemap.xml"],
+	"sitemap_alternate_links": true,
+	"stop_urls": [],
+	"selectors": {
+		"lvl0": {
+			"selector": "(//ul[contains(@class,'menu__list')]//a[contains(@class, 'menu__link menu__link--sublist menu__link--active')]/text() | //nav[contains(@class, 'navbar')]//a[contains(@class, 'navbar__link--active')]/text())[last()]",
+			"type": "xpath",
+			"global": true,
+			"default_value": "Documentation"
+		},
+		"lvl1": "header h1",
+		"lvl2": "article h2",
+		"lvl3": "article h3",
+		"lvl4": "article h4",
+		"lvl5": "article h5, article td:first-child",
+		"lvl6": "article h6",
+		"text": "article p, article li, article td:last-child"
+	},
+	"strip_chars": " .,;:#",
+	"custom_settings": {
+		"separatorsToIndex": "_",
+		"attributesForFaceting": ["language", "version", "type", "docusaurus_tag"],
+		"attributesToRetrieve": [
+			"hierarchy",
+			"content",
+			"anchor",
+			"url",
+			"url_without_anchor",
+			"type"
+		]
+	},
+	"conversation_id": ["833762294"],
+	"nb_hits": 16653
 }

--- a/config.example.json
+++ b/config.example.json
@@ -1,37 +1,20 @@
 {
-	"index_name": "cpnotes_index",
-	"start_urls": ["https://cpnotes-preview.netlify.app/"],
-	"sitemap_urls": ["https://cpnotes-preview.netlify.app/sitemap.xml"],
-	"sitemap_alternate_links": true,
-	"stop_urls": [],
-	"selectors": {
-		"lvl0": {
-			"selector": "(//ul[contains(@class,'menu__list')]//a[contains(@class, 'menu__link menu__link--sublist menu__link--active')]/text() | //nav[contains(@class, 'navbar')]//a[contains(@class, 'navbar__link--active')]/text())[last()]",
-			"type": "xpath",
-			"global": true,
-			"default_value": "Documentation"
-		},
-		"lvl1": "header h1",
-		"lvl2": "article h2",
-		"lvl3": "article h3",
-		"lvl4": "article h4",
-		"lvl5": "article h5, article td:first-child",
-		"lvl6": "article h6",
-		"text": "article p, article li, article td:last-child"
-	},
-	"strip_chars": " .,;:#",
-	"custom_settings": {
-		"separatorsToIndex": "_",
-		"attributesForFaceting": ["language", "version", "type", "docusaurus_tag"],
-		"attributesToRetrieve": [
-			"hierarchy",
-			"content",
-			"anchor",
-			"url",
-			"url_without_anchor",
-			"type"
-		]
-	},
-	"conversation_id": ["833762294"],
-	"nb_hits": 16653
+  "index_name": "algolia_docsearch_action",
+  "start_urls": [
+    "https://aquaimpact.github.io/CovidSusTrackerDocs"
+  ],
+  "stop_urls": [],
+  "selectors": {
+    "lvl0": ".doc-content h1",
+    "lvl1": ".doc-content h2",
+    "lvl2": ".doc-content h3",
+    "lvl3": ".doc-content h4",
+    "lvl4": ".doc-content h5",
+    "lvl5": ".doc-content h6",
+    "text": ".doc-content p, .doc-content li"
+  },
+  "conversation_id": [
+    "1313246279"
+  ],
+  "nb_hits": 98
 }

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -19,8 +19,14 @@ FILE=$3
 
 # ---- NEED TO REPLACE WITH CUSTOM ACTION
 
-ls -la $GITHUB_WORKSPACE
-cat $GITHUB_WORKSPACE/$FILE | jq -r tostring
+echo "the files are "
+ls -a
+# cat $GITHUB_WORKSPACE/$FILE | jq -r tostring
+
+echo "=========
+and using tree command"
+
+tree .
 
 echo "reached something!"
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,17 +4,16 @@ APPLICATION_ID=$1
 API_KEY=$2
 FILE=$3
 
+echo "\n the dirs are \n"
+
+ls -a
+
 cd docsearch-scraper/
 
 echo "APPLICATION_ID=${APPLICATION_ID}
 API_KEY=${API_KEY}
 " > .env
 
-ls -a
-
-echo "above were the present"
-
 ls -a $GITHUB_WORKSPACE
 
-pipenv shell
-./docsearch run $GITHUB_WORKSPACE/config.example.json
+python docsearch run $GITHUB_WORKSPACE/config.example.json

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,15 +4,13 @@ APPLICATION_ID=$1
 API_KEY=$2
 FILE=$3
 
-apt update && apt install git -y
-
 git clone https://github.com/algolia/docsearch-scraper.git
 
 cd docsearch-scraper/
 
-pip install pipenv
+pip install --no-cache-dir --trusted-host pypi.python.org pipenv
 
-pipenv install --system --ignore-pipfile
+pipenv install --system --deploy --ignore-pipfile
 
 echo "APPLICATION_ID=${APPLICATION_ID}
 API_KEY=${API_KEY}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,30 +4,13 @@ APPLICATION_ID=$1
 API_KEY=$2
 FILE=$3
 
-# apt update
-# apt install jq -y
+cd docsearch-scraper/
 
-# --- THE MAIN PROBLEM LIES HERE
+echo "APPLICATION_ID=${APPLICATION_ID}
+API_KEY=${API_KEY}
+" > .env
 
-# install docker
-# apt install apt-transport-https ca-certificates curl software-properties-common -y
-# curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add -
-# add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu bionic stable"
-# apt update
-# apt-cache policy docker-ce
-# apt install docker-ce -y
+ls -a $GITHUB_WORKSPACE
 
-# ---- NEED TO REPLACE WITH CUSTOM ACTION
-
-echo "the files are "
-ls -a
-# cat $GITHUB_WORKSPACE/$FILE | jq -r tostring
-
-echo "=========
-and using tree command"
-
-tree .
-
-echo "reached something!"
-
-# docker run -e APPLICATION_ID=$APPLICATION_ID -e API_KEY=$API_KEY -e "CONFIG=$(cat $GITHUB_WORKSPACE/$FILE | jq -r tostring)" algolia/docsearch-scraper
+pipenv shell
+./docsearch run $GITHUB_WORKSPACE/config.example.json

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -21,4 +21,7 @@ FILE=$3
 
 ls -la $GITHUB_WORKSPACE
 cat $GITHUB_WORKSPACE/$FILE | jq -r tostring
-docker run -e APPLICATION_ID=$APPLICATION_ID -e API_KEY=$API_KEY -e "CONFIG=$(cat $GITHUB_WORKSPACE/$FILE | jq -r tostring)" algolia/docsearch-scraper
+
+echo "reached something!"
+
+# docker run -e APPLICATION_ID=$APPLICATION_ID -e API_KEY=$API_KEY -e "CONFIG=$(cat $GITHUB_WORKSPACE/$FILE | jq -r tostring)" algolia/docsearch-scraper

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -7,6 +7,8 @@ FILE=$3
 apt update
 apt install jq -y
 
+# --- THE MAIN PROBLEM LIES HERE
+
 # install docker
 apt install apt-transport-https ca-certificates curl software-properties-common -y
 curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add -
@@ -14,6 +16,8 @@ add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu bi
 apt update
 apt-cache policy docker-ce
 apt install docker-ce -y
+
+# ---- NEED TO REPLACE WITH CUSTOM ACTION
 
 ls -la $GITHUB_WORKSPACE
 cat $GITHUB_WORKSPACE/$FILE | jq -r tostring

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -10,6 +10,10 @@ echo "APPLICATION_ID=${APPLICATION_ID}
 API_KEY=${API_KEY}
 " > .env
 
+ls -a
+
+echo "above were the present"
+
 ls -a $GITHUB_WORKSPACE
 
 pipenv shell

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,11 +4,13 @@ APPLICATION_ID=$1
 API_KEY=$2
 FILE=$3
 
-echo "\n the dirs are \n"
-
-ls -a
+git clone https://github.com/algolia/docsearch-scraper.git
 
 cd docsearch-scraper/
+
+pip install pipenv
+
+pipenv install --system --ignore-pipfile
 
 echo "APPLICATION_ID=${APPLICATION_ID}
 API_KEY=${API_KEY}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -17,3 +17,5 @@ API_KEY=${API_KEY}
 " > .env
 
 python docsearch run $GITHUB_WORKSPACE/$FILE
+
+echo "🚀 Successfully indexed and uploaded the results to Algolia"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,18 +4,23 @@ APPLICATION_ID=$1
 API_KEY=$2
 FILE=$3
 
+# build from the main source repository
 git clone https://github.com/algolia/docsearch-scraper.git
 
 cd docsearch-scraper/
 
+# install pipenv without cache
 pip install --no-cache-dir --trusted-host pypi.python.org pipenv
 
+# install packages without virtualenv
 pipenv install --system --deploy --ignore-pipfile
 
+# create the .env file for docsearch
 echo "APPLICATION_ID=${APPLICATION_ID}
 API_KEY=${API_KEY}
 " > .env
 
+# run algolia docsearch
 python docsearch run $GITHUB_WORKSPACE/$FILE
 
 echo "🚀 Successfully indexed and uploaded the results to Algolia"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,18 +4,18 @@ APPLICATION_ID=$1
 API_KEY=$2
 FILE=$3
 
-apt update
-apt install jq -y
+# apt update
+# apt install jq -y
 
 # --- THE MAIN PROBLEM LIES HERE
 
 # install docker
-apt install apt-transport-https ca-certificates curl software-properties-common -y
-curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add -
-add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu bionic stable"
-apt update
-apt-cache policy docker-ce
-apt install docker-ce -y
+# apt install apt-transport-https ca-certificates curl software-properties-common -y
+# curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add -
+# add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu bionic stable"
+# apt update
+# apt-cache policy docker-ce
+# apt install docker-ce -y
 
 # ---- NEED TO REPLACE WITH CUSTOM ACTION
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,6 +4,8 @@ APPLICATION_ID=$1
 API_KEY=$2
 FILE=$3
 
+apt update && apt install git -y
+
 git clone https://github.com/algolia/docsearch-scraper.git
 
 cd docsearch-scraper/

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -16,6 +16,4 @@ echo "APPLICATION_ID=${APPLICATION_ID}
 API_KEY=${API_KEY}
 " > .env
 
-ls -a $GITHUB_WORKSPACE
-
-python docsearch run $GITHUB_WORKSPACE/config.example.json
+python docsearch run $GITHUB_WORKSPACE/$FILE


### PR DESCRIPTION
# Short Description

Instead of using the [docker image by algolia](https://docsearch.algolia.com/docs/run-your-own/#run-the-crawl-from-the-docker-image) for docsearch, this pr uses [the source repository](https://github.com/algolia/docsearch-scraper) for scrapping and uploading to algolia.

# Details

Using the source repository, removes the use of [jq](https://github.com/stedolan/jq/wiki/Installation), installation of docker-cli, the algolia docsearch docker image, and other peer dependencies.

Using the [python:3.6](https://hub.docker.com/_/python) as the base image (which comes with git preinstalled), first the [algolia-docsearch repository](https://github.com/algolia/docsearch-scraper) is _git cloned_.
`pipenv` is installed and then `pipenv` installed the packages in the Pipfile.

With these setup, now we can easily run:
```
python docsearch run $GITHUB_WORKSPACE/$FILE
```

# Improvements

The running time of the action has now **reduced by 40 seconds**.

You can have a look at the comparison run in [here](https://github.com/aditya-mitra/temptemp/actions/runs/963793337)

![image](https://user-images.githubusercontent.com/55396651/123076009-5be52b00-d436-11eb-8f99-e1f346862de0.png)

# Further Comments

I have made a few other fixes/corrections like correcting the spelling of algolia.

Also, I changed the `config.example.json` since it took a lot of time to index and the difference could not have been made clear.

# Related Issues

Closes #2 