### PR TITLE
Fix: python run in subshell

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -21,6 +21,6 @@ API_KEY=${API_KEY}
 " > .env
 
 # run algolia docsearch
-python docsearch run $GITHUB_WORKSPACE/$FILE
+exec python docsearch run $GITHUB_WORKSPACE/$FILE
 
 echo "🚀 Successfully indexed and uploaded the results to Algolia"


### PR DESCRIPTION
Cause u run python inside an own shell we have two problems:
* External signals like `TERM` are not forwarded to python
* If python fails, the docker-run still terminates with `0` and an gh-action succeeds.